### PR TITLE
Reuse database connection and close it after loop

### DIFF
--- a/src/main/java/com/rc/spoonbill/test/interceptor/JsonDataSetInterceptor.java
+++ b/src/main/java/com/rc/spoonbill/test/interceptor/JsonDataSetInterceptor.java
@@ -3,6 +3,7 @@ package com.rc.spoonbill.test.interceptor;
 import java.util.Stack;
 
 import org.dbunit.IDatabaseTester;
+import org.dbunit.database.IDatabaseConnection;
 import org.dbunit.dataset.IDataSet;
 import org.dbunit.operation.DatabaseOperation;
 import org.spockframework.runtime.extension.AbstractMethodInterceptor;
@@ -57,14 +58,16 @@ public class JsonDataSetInterceptor extends AbstractMethodInterceptor {
     public void interceptCleanupMethod(IMethodInvocation invocation) throws Throwable {
 
         int stackSize = dataSets.size();
+        IDatabaseConnection connection = databaseTester.getConnection();
+
         for (int seq = 0; seq < stackSize; seq++) {
 
             IDataSet dataSet = dataSets.pop();
-            DatabaseOperation.CLEAN_INSERT.execute(databaseTester.getConnection(), dataSet);
-            DatabaseOperation.DELETE_ALL.execute(databaseTester.getConnection(), dataSet);
+            DatabaseOperation.CLEAN_INSERT.execute(connection, dataSet);
+            DatabaseOperation.DELETE_ALL.execute(connection, dataSet);
         }
 
-        databaseTester.getConnection().close();
+        connection.close();
         databaseTester.onTearDown();
 
         invocation.proceed();


### PR DESCRIPTION
Try to solve issue

```
org.apache.tomcat.jdbc.pool.PoolExhaustedException: [main] Timeout: Pool empty. Unable to fetch a connection in 30 seconds, none available[size:100; busy:100; idle:0; lastwait:30000].
        at org.apache.tomcat.jdbc.pool.ConnectionPool.borrowConnection(ConnectionPool.java:681)
        at org.apache.tomcat.jdbc.pool.ConnectionPool.getConnection(ConnectionPool.java:185)
        at org.apache.tomcat.jdbc.pool.DataSourceProxy.getConnection(DataSourceProxy.java:127)
        at org.dbunit.DataSourceDatabaseTester.getConnection(DataSourceDatabaseTester.java:88)
        at com.rc.spoonbill.test.interceptor.JsonDataSetInterceptor.interceptCleanupMethod(JsonDataSetInterceptor.java:67)
```
